### PR TITLE
[Bugfix] Fix the main reference in the package.json to point to the generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "files": [
     "generators"
   ],
-  "main": "generators/index.js",
+  "main": "generators/app/index.js",
   "keywords": [
     "redux",
     "react",


### PR DESCRIPTION
Hi @jonidelv, thanks for creating this generator!

I'm using an unconventional way of using yeoman generators by installing the package and then manually calling `environment.get(path)` which requires the generator itself.

When requiring your generator, it can't find the main file which results in an error :(

I *think* but I'm not 100% sure, when installing using the global generator, it uses the namespace feature to find the directory which is different from using the full path (which I am doing). If this isn't the correct fix, please let me know!